### PR TITLE
bug fix for error at exist and cptOption in model file

### DIFF
--- a/src/util/model.js
+++ b/src/util/model.js
@@ -162,11 +162,12 @@ export function mappingToExists(exists, newCptOptions) {
             var exist = result[i].exist;
             if (!result[i].option // Consider name: two map to one.
                 // Can not match when both ids exist but different.
-                && (exist.id == null || cptOption.id == null)
-                && cptOption.name != null
+                && ((exist && exist.id == null) || (cpOption && cptOption.id == null))
+                && (cptOption && cptOption.name != null)
                 && !isIdInner(cptOption)
                 && !isIdInner(exist)
-                && exist.name === cptOption.name + ''
+                && exist && cptOption
+                &&  exist.name === cptOption.name + ''
             ) {
                 result[i].option = cptOption;
                 newCptOptions[index] = null;


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

This fixes the issue of error throwing from exist or cptOption. When exist and cptOption is undefined it throws error.

### Fixed issues

<!--
- #xxxx: ...
-->


## Details

### Before: What was the problem?

<!-- DESCRIBE THE BUG OR REQUIREMENT HERE. -->
Whenever exist and cptOption is undefined it throws a error. 
I was facing the issue for dynamic line bar chart. 
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



### After: How is it fixed in this PR?

<!-- THE RESULT AFTER FIXING AND A SIMPLE EXPLANATION ABOUT HOW IT IS FIXED. -->
By checking the value for exist and cptOption it solved the issue.
<!-- ADD SCREENSHOT HERE IF APPLICABLE. -->



## Usage

### Are there any API changes?

- [ ] The API has been changed.

<!-- LIST THE API CHANGES HERE -->



### Related test cases or examples to use the new APIs

NA.



## Others

### Merging options

- [ ] Please squash the commits into a single one when merge.

### Other information
